### PR TITLE
Return a protocol-relative URL in concat_script_tag().

### DIFF
--- a/wistia-anti-mangler.php
+++ b/wistia-anti-mangler.php
@@ -569,7 +569,7 @@ class WistiaAntiMangler {
    * @return  array
    */
   function concat_script_tag($scripts) {
-    return '<script charset="ISO-8859-1" src="http' . ($_SERVER['https'] == 'on' ? 's' : '') . '://fast.wistia.com/static/concat/' . implode($scripts, '%2C') . '.js"></script>';
+    return '<script src="//fast.wistia.com/static/concat/' . implode($scripts, '%2C') . '.js"></script>';
   }
 }
 ?>


### PR DESCRIPTION
Changing to a protocol-relative URI fixes the issue of trying to determine if SSL is active on a server by letting the browser take care of the loading for us. Since the subdomains don't change if SSL is used, the browser will be able to negotiate the protocol for us.
